### PR TITLE
Feature: Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.7-dev"  # 3.7 development branch
+  - "3.8-dev"  # 3.8 development branch
+  - "nightly"  # nightly build
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - black --check
+  - mypy
+  - pylint --errors-only
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - black --check
-  - mypy
-  - pylint --errors-only
-  - pytest
+  - black --check dodeka/
+  - mypy dodeka/
+  - pylint --errors-only dodeka/
+  - pytest dodeka/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # dodeka
 
+[![Build Status](https://travis-ci.org/shimst3r/dodeka.svg?branch=master)](https://travis-ci.org/shimst3r/dodeka)
+
 dodeka is a command line tool for tracking twelve-factor app fulfilment


### PR DESCRIPTION
# Description
With this PR, I add [Travis](https://travis-ci.org) support to the project. Travis will be the project's CI platform until I can afford something else. 😄 

This includes:
* `.travis.yml` config file,
* a `build` icon in the README.md file.