### PR TITLE
"Improvement": Remove Python 3.6 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
-  - "3.6"
   - "3.7"
-  - "3.7-dev"  # 3.7 development branch
-  - "3.8-dev"  # 3.8 development branch
-  - "nightly"  # nightly build
+  - "3.7-dev"
+  - "3.8-dev" 
+  - "nightly" 
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
# Description

Because the project aims to use the most recent Python features, I decided on making Python 3.7 the base line which Travis is going to test and build against.

Sadly this means I won't support anything below 3.7 as of yet, but I bet this will be just a matter of time once I have the time to implement workarounds. 💪 