### PR TITLE
Bugfix: Add jinja2 to setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as f_in:
 
 PACKAGES = ["dodeka"]
 
-REQUIRES = ["Click"]
+REQUIRES = ["Click", "jinja2"]
 
 setup(
     author="Nils P. Müller",


### PR DESCRIPTION
# Description
With this PR, `jinja2` is added to the installation requirements of `setup.py`.