### PR TITLE
Feature: Implement basic CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ list_of_factors = factors.generate_factors()
 print(factors.generate_checklist(factors=list_of_factors))
 ```
 
-In one of the next releases, this will be implemented as a command line interface.
+If installed from PyPI, `dodeka` can also be used from the command line:
+
+```sh
+dodeka --help
+```
 
 ## How to Test
 

--- a/dodeka/interface.py
+++ b/dodeka/interface.py
@@ -1,0 +1,23 @@
+"""
+Copyright (c) 2019, Nils P. Müller <shimst3r@gmail.com>
+All rights reserved.
+
+This file is part of dodeka.
+
+`interface.py` implements the command line interface. 
+
+License: MIT, see https://opensource.org/licenses/MIT
+"""
+import click
+
+from dodeka import factors
+
+
+@click.command()
+def dodeka():
+    """
+    dodeka is a command line tool for tracking the degree of fulfilment of The
+    Twelve-Factor App methodology. Use it in your projects to test whether they
+    conform to the principles for developing solid web apps that originated
+    within Heroku.
+    """

--- a/dodeka/test_interface.py
+++ b/dodeka/test_interface.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2019, Nils P. Müller <shimst3r@gmail.com>
+All rights reserved.
+
+This file is part of dodeka.
+
+`test_interface.py` tests the command line interface as
+implemented in `interface.py`.
+
+License: MIT, see https://opensource.org/licenses/MIT
+"""
+
+import click.testing
+
+from dodeka import interface
+
+
+def test_dodeka_help():
+    expected = (
+        "Usage: dodeka [OPTIONS]\n"
+        "\n"
+        "  dodeka is a command line tool for tracking the degree of fulfilment of The\n"
+        "  Twelve-Factor App methodology. Use it in your projects to test whether they\n"
+        "  conform to the principles for developing solid web apps that originated\n"
+        "  within Heroku.\n"
+        "\n"
+        "Options:\n"
+        "  --help  Show this message and exit.\n"
+    )
+
+    runner = click.testing.CliRunner()
+    actual = runner.invoke(interface.dodeka, args=["--help"]).output
+
+    assert actual == expected

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,15 @@ atomicwrites==1.3.0
 attrs==19.3.0
 black==19.3b0
 Click==7.0
+docutils==0.15.2
 importlib-metadata==0.23
 isort==4.3.21
 Jinja2==2.10.3
 lazy-object-proxy==1.4.2
+m2r==0.2.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
+mistune==0.8.4
 more-itertools==7.2.0
 mypy==0.730
 mypy-extensions==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,17 @@ License: MIT, see https://opensource.org/licenses/MIT
 
 from setuptools import setup
 
-__version__ = "0.1.1"
+import m2r
 
+__version__ = "0.2.0"
+
+ENTRY_POINTS = {"console_scripts": ["dodeka = dodeka.interface:dodeka"]}
+
+# The README is written using markdown, PyPI expects the long description
+# to be written in reStructuredText. Thus the `m2r` converter is used
+# for converting between the two.
 with open("README.md", "r", encoding="utf-8") as f_in:
-    LONG_DESCRIPTION = f_in.read()
+    LONG_DESCRIPTION = m2r.convert(f_in.read())
 
 PACKAGES = ["dodeka"]
 
@@ -30,7 +37,8 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     description="Twelve-Factor App Checker",
-    download_url="https://github.com/shimst3r/dodeka/archive/0.1.1.tar.gz",
+    download_url=f"https://github.com/shimst3r/dodeka/archive/{__version__}.tar.gz",
+    entry_points=ENTRY_POINTS,
     install_requires=REQUIRES,
     keywords=["cli", "tool", "twelvefactor"],
     license="MIT",


### PR DESCRIPTION
# Description

With this PR, I implement a very basic command line interface based on [`Click`](https://click.palletsprojects.com/en/7.x/). So far it only displays the help text if called via

```sh
dodeka --help
```

Furthermore I added a `script_entrypoint` to `setup.py` and introduced [`m2r`](https://github.com/miyakogi/m2r) to the project, so that the description on PyPI is properly formatted using reStructuredText.